### PR TITLE
AWS S3 github action resource upload

### DIFF
--- a/.github/workflows/s3-resources-upload.yml
+++ b/.github/workflows/s3-resources-upload.yml
@@ -1,0 +1,48 @@
+name: Upload learning resources to S3
+on:
+  workflow_dispatch:
+    branches:
+      - main
+      - master
+      - draft
+  push:
+    branches:
+      - main
+      - master
+      - draft
+jobs:
+  s3-resources-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Environment lookup
+        id: env_lookup
+        run: |
+          BRANCH=${GITHUB_REF#refs/heads/}
+          echo "Running on branch $BRANCH"
+          if [[ "master,main" == *"$BRANCH"* ]]; then
+            echo "::set-output name=ENV::PRODUCTION"
+          elif [ "$BRANCH" = "draft" ]; then
+            echo "::set-output name=ENV::STAGING"
+          else
+             echo "::set-output name=ENV::FEATURE"
+          fi
+      - name: Debug Environment
+        run: |
+          echo "Setting environment to ${{ steps.env_lookup.outputs.ENV }}"
+      - uses: actions/checkout@v3
+        if: steps.env_lookup.outputs.ENV == 'PRODUCTION' || steps.env_lookup.outputs.ENV == 'STAGING'
+      - name: Configure AWS Credentials
+        if: steps.env_lookup.outputs.ENV == 'PRODUCTION' || steps.env_lookup.outputs.ENV == 'STAGING'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets[format('AWS_ACCESS_KEY_ID_{0}', steps.env_lookup.outputs.ENV)] }}
+          aws-secret-access-key: ${{ secrets[format('AWS_SECRET_ACCESS_KEY_{0}', steps.env_lookup.outputs.ENV)] }}
+          aws-region: eu-west-2
+      - name: Deploy static assets to S3 bucket
+        if: steps.env_lookup.outputs.ENV == 'PRODUCTION' || steps.env_lookup.outputs.ENV == 'STAGING'
+        run: |
+          if [[ "${{ steps.env_lookup.outputs.ENV }}" == "PRODUCTION" ]]; then
+            aws s3 sync . s3://learning-resources-production/projects/${{ github.event.repository.name }}/${{ github.sha }}/ --exclude "*" --include "*/images/*" --include "*/resources/*" --include "*/solutions/*" --delete --size-only
+          elif [[ "${{ steps.env_lookup.outputs.ENV }}" == "STAGING" ]]; then
+            aws s3 sync . s3://learning-resources-dev-staging/projects/${{ github.event.repository.name }}/${{ github.sha }}/ --exclude "*" --include "*/images/*" --include "*/resources/*" --include "*/solutions/*" --delete --size-only
+          fi


### PR DESCRIPTION
Related to https://github.com/RaspberryPiFoundation/projects-admin/issues/1140

Changes:

deploy on pushed to master/main and draft (set to production and staging respectively)
deploy images/resources/solutions directories to the correct bucket in the same git sha structure
use sync to allow this workflow to be called multiple times but only upload the differences
use workflow_dispatch to allow the workflow to be triggered via a POST request